### PR TITLE
Add @toptl/grammy — TOP.TL bot stats plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,4 @@ This is a curated list of projects that are using grammY. Anyone is welcome to t
 ## Plugins
 
 - [VDS13/telegram-inline-calendar](https://github.com/VDS13/telegram-inline-calendar) - Date picker and inline calendar for your bots.
+- [@toptl/grammy](https://github.com/top-tl/grammy) - Plugin for TOP.TL, the Telegram directory. Auto-posts bot stats and enables vote-gating.


### PR DESCRIPTION
Adds [@toptl/grammy](https://www.npmjs.com/package/@toptl/grammy) to the list.

TOP.TL is a community-ranked Telegram directory (like top.gg for Telegram). This plugin auto-tracks bot users/groups/channels and posts stats, with vote-checking middleware.

npm: https://www.npmjs.com/package/@toptl/grammy
GitHub: https://github.com/top-tl/grammy