### PR TITLE
Add IgorShadurin/weight-telegram-bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This is a curated list of projects that are using grammY. Anyone is welcome to t
 - [Burhanverse/tunified](https://github.com/Burhanverse/Tunified) - A Telegram bot to fetch the currently playing song from Last.fm and shares it on Telegram.
 - [Taofeekabdulazeez/word-ninjas](https://github.com/Taofeekabdulazeez/word-ninjas) - A game where multiple players compete to solve anagrams in real-time.
 - [SpEcHiDe/JsonBot](https://github.com/SpEcHiDe/JsonBot) - A bot that sends the JSON representations of most of the updates of the Bot API.
-- [IgorShadurin/weight-telegram-bot](https://github.com/IgorShadurin/weight-telegram-bot) - Track photo-backed weekly weight goals in groups with charts, reminders, and achievements. [ᴜsᴇ](https://t.me/my_weight_goal_bot).
+- [IgorShadurin/weight-telegram-bot](https://github.com/IgorShadurin/weight-telegram-bot) - Track photo-backed weekly weight goals in groups with charts, reminders, 53 achievements, and nine natural localizations. [ᴜsᴇ](https://t.me/my_weight_goal_bot).
 
 ## Templates
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This is a curated list of projects that are using grammY. Anyone is welcome to t
 - [Burhanverse/tunified](https://github.com/Burhanverse/Tunified) - A Telegram bot to fetch the currently playing song from Last.fm and shares it on Telegram.
 - [Taofeekabdulazeez/word-ninjas](https://github.com/Taofeekabdulazeez/word-ninjas) - A game where multiple players compete to solve anagrams in real-time.
 - [SpEcHiDe/JsonBot](https://github.com/SpEcHiDe/JsonBot) - A bot that sends the JSON representations of most of the updates of the Bot API.
+- [IgorShadurin/weight-telegram-bot](https://github.com/IgorShadurin/weight-telegram-bot) - Track photo-backed weekly weight goals in groups with charts, reminders, and achievements. [ᴜsᴇ](https://t.me/my_weight_goal_bot).
 
 ## Templates
 


### PR DESCRIPTION
## Summary

Adds [Weight Goal Bot](https://t.me/my_weight_goal_bot) to the list of production bots built with grammY. Its [Apache-2.0 source](https://github.com/IgorShadurin/weight-telegram-bot) uses grammY with TypeScript and provides photo-backed weekly weight goals, progress charts, reminders, and 53 achievements. The complete interface is naturally adapted for English, Russian, Chinese, Spanish, Portuguese, German, French, Japanese, and Indonesian.

## Verification

- [x] The project directly depends on and uses grammY
- [x] The live bot and public source links resolve
- [x] The repository contains an Apache-2.0 license and README screenshots
- [x] The entry follows the required format, is at the bottom of Bots, and is not a duplicate